### PR TITLE
Support RedisGraph 2.1.0+

### DIFF
--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -1,7 +1,7 @@
 use crate::{
     assignments::FromCell,
     client_type_error,
-    result_set::{Node, Path, Relation, Scalar},
+    result_set::{Node, Path, Edge, Scalar},
     RedisGraphError, RedisGraphResult, RedisString, ResultSet,
 };
 
@@ -157,14 +157,14 @@ impl FromCell for Node {
     }
 }
 
-impl FromCell for Relation {
+impl FromCell for Edge {
     fn from_cell(
         result_set: &ResultSet,
         row_idx: usize,
         column_idx: usize,
     ) -> RedisGraphResult<Self> {
-        let relation = result_set.get_relation(row_idx, column_idx)?;
-        Ok(relation.clone())
+        let edge = result_set.get_edge(row_idx, column_idx)?;
+        Ok(edge.clone())
     }
 }
 

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -1,7 +1,7 @@
 use crate::{
     assignments::FromCell,
     client_type_error,
-    result_set::{Node, Relation, Scalar},
+    result_set::{Node, Path, Relation, Scalar},
     RedisGraphError, RedisGraphResult, RedisString, ResultSet,
 };
 
@@ -165,5 +165,16 @@ impl FromCell for Relation {
     ) -> RedisGraphResult<Self> {
         let relation = result_set.get_relation(row_idx, column_idx)?;
         Ok(relation.clone())
+    }
+}
+
+impl FromCell for Path {
+    fn from_cell(
+        result_set: &ResultSet,
+        row_idx: usize,
+        column_idx: usize,
+    ) -> RedisGraphResult<Self> {
+        let path = result_set.get_path(row_idx, column_idx)?;
+        Ok(path.clone())
     }
 }

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -1,8 +1,8 @@
 use crate::{
     assignments::FromCell,
     client_type_error,
-    result_set::{Node, Path, Edge, Scalar},
-    RedisGraphError, RedisGraphResult, RedisString, ResultSet,
+    RedisGraphError,
+    RedisGraphResult, RedisString, result_set::{Edge, Node, Path, RawPath, Scalar}, ResultSet,
 };
 
 impl FromCell for Scalar {
@@ -168,7 +168,7 @@ impl FromCell for Edge {
     }
 }
 
-impl FromCell for Path {
+impl FromCell for RawPath {
     fn from_cell(
         result_set: &ResultSet,
         row_idx: usize,
@@ -176,5 +176,16 @@ impl FromCell for Path {
     ) -> RedisGraphResult<Self> {
         let path = result_set.get_path(row_idx, column_idx)?;
         Ok(path.clone())
+    }
+}
+
+impl FromCell for Path {
+    fn from_cell(
+        result_set: &ResultSet,
+        row_idx: usize,
+        column_idx: usize,
+    ) -> RedisGraphResult<Self> {
+        let path = result_set.get_path(row_idx, column_idx)?;
+        Ok(path.clone().into())
     }
 }

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -4,6 +4,7 @@ use crate::{
     RedisGraphError,
     RedisGraphResult, RedisString, result_set::{Edge, Node, Path, RawPath, Scalar}, ResultSet,
 };
+use std::convert::TryInto;
 
 impl FromCell for Scalar {
     fn from_cell(
@@ -186,6 +187,6 @@ impl FromCell for Path {
         column_idx: usize,
     ) -> RedisGraphResult<Self> {
         let path = result_set.get_path(row_idx, column_idx)?;
-        Ok(path.clone().into())
+        path.clone().try_into()
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,54 +1,54 @@
 #![doc(html_logo_url = "https://oss.redislabs.com/redisgraph/images/logo_small.png")]
 
 //! # redisgraph-rs
-//! 
+//!
 //! `redisgraph-rs` is an idiomatic Rust client for RedisGraph, the graph database by Redis.
-//! 
+//!
 //! This crate parses responses from RedisGraph and converts them into ordinary Rust values.
 //! It exposes a very flexible API that allows you to retrieve a single value, a single record
 //! or multiple records using only one function: [`Graph::query`](graph/struct.Graph.html#method.query).
-//! 
+//!
 //! If you want to use this crate, add this to your Cargo.toml:
-//! 
+//!
 //! ```ini
 //! [dependencies]
 //! redis = "0.15.1"
 //! redisgraph = "0.1.0"
 //! ```
-//! 
+//!
 //! **Warning**: This library has not been thoroughly tested yet and some features are still missing.
 //! Expect bugs and breaking changes.
-//! 
+//!
 //! ## Resources
-//! 
+//!
 //! - RedisGraph documentation: [redisgraph.io][]
 //! - API Reference: [docs.rs/redisgraph]
-//! 
+//!
 //! ## Example
-//! 
+//!
 //! First, run RedisGraph on your machine using
-//! 
+//!
 //! ```sh
 //! $ docker run --name redisgraph-test -d --rm -p 6379:6379 redislabs/redisgraph
 //! ```
-//! 
+//!
 //! Then, try out this code:
-//! 
+//!
 //! ```rust
 //! use redis::Client;
 //! use redisgraph::{Graph, RedisGraphResult};
-//! 
+//!
 //! fn main() -> RedisGraphResult<()> {
-//!     let client = Client::open("redis://127.0.0.1")?;
+//!     let client = Client::open(option_env!("TEST_REDIS_URI").unwrap_or("redis://127.0.0.1"))?;
 //!     let mut connection = client.get_connection()?;
-//! 
+//!
 //!     let mut graph = Graph::open(connection, "MotoGP".to_string())?;
-//! 
+//!
 //!     // Create six nodes (three riders, three teams) and three relationships between them.
 //!     graph.mutate("CREATE (:Rider {name: 'Valentino Rossi', birth_year: 1979})-[:rides]->(:Team {name: 'Yamaha'}), \
 //!         (:Rider {name:'Dani Pedrosa', birth_year: 1985, height: 1.58})-[:rides]->(:Team {name: 'Honda'}), \
 //!         (:Rider {name:'Andrea Dovizioso', birth_year: 1986, height: 1.67})-[:rides]->(:Team {name: 'Ducati'})")?;
-//! 
+//!
 //!     // Get the names and birth years of all riders in team Yamaha.
 //!     let results: Vec<(String, u32)> = graph.query("MATCH (r:Rider)-[:rides]->(t:Team) WHERE t.name = 'Yamaha' RETURN r.name, r.birth_year")?;
 //!     // Since we know just one rider in our graph rides for team Yamaha,
@@ -57,14 +57,14 @@
 //!     // Let's now get all the data about the riders we have.
 //!     // Be aware of that we only know the height of some riders, and therefore we use an `Option`:
 //!     let results: Vec<(String, u32, Option<f32>)> = graph.query("MATCH (r:Rider) RETURN r.name, r.birth_year, r.height")?;
-//! 
+//!
 //!     // That was just a demo; we don't need this graph anymore. Let's delete it from the database:
 //!     graph.delete()?;
-//! 
+//!
 //!     Ok(())
 //! }
 //! ```
-//! 
+//!
 //! [redisgraph.io]:https://redisgraph.io
 //! [docs.rs/redisgraph]:https://docs.rs/redisgraph
 

--- a/src/result_set.rs
+++ b/src/result_set.rs
@@ -346,7 +346,6 @@ fn parse_statistics(value: Value) -> RedisGraphResult<Statistics> {
 
 /// A scalar value returned by RedisGraph.
 #[derive(Debug, Clone, PartialEq)]
-#[non_exhaustive]
 pub enum Scalar {
     Nil,
     Boolean(bool),

--- a/tests/assignments_test.rs
+++ b/tests/assignments_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use redisgraph::{RedisGraphResult};
+use redisgraph::RedisGraphResult;
 use serial_test::serial;
 
 use common::*;
@@ -29,8 +29,12 @@ fn test_tuple() {
 #[serial]
 fn test_vec() {
     with_graph(|graph| {
-        graph.mutate("CREATE (n1 { prop: 1 }), (n2 { prop: 2 }), (n3 { prop: 3 })").unwrap();
-        let vec: Vec<i64> = graph.query("MATCH (n) RETURN n.prop ORDER BY n.prop").unwrap();
+        graph
+            .mutate("CREATE (n1 { prop: 1 }), (n2 { prop: 2 }), (n3 { prop: 3 })")
+            .unwrap();
+        let vec: Vec<i64> = graph
+            .query("MATCH (n) RETURN n.prop ORDER BY n.prop")
+            .unwrap();
         assert_eq!(vec[0], 1);
         assert_eq!(vec[1], 2);
         assert_eq!(vec[2], 3);
@@ -42,7 +46,9 @@ fn test_vec() {
 fn test_tuple_vec() {
     with_graph(|graph| {
         graph.mutate("CREATE (n1 { num: 1, word: 'foo' }), (n2 { num: 2, word: 'bar' }), (n3 { num: 3, word: 'baz' })").unwrap();
-        let tuple_vec: Vec<(i64, String)> = graph.query("MATCH (n) RETURN n.num, n.word ORDER BY n.num").unwrap();
+        let tuple_vec: Vec<(i64, String)> = graph
+            .query("MATCH (n) RETURN n.num, n.word ORDER BY n.num")
+            .unwrap();
         assert_eq!(tuple_vec[0], (1, "foo".to_string()));
         assert_eq!(tuple_vec[1], (2, "bar".to_string()));
         assert_eq!(tuple_vec[2], (3, "baz".to_string()));
@@ -53,7 +59,8 @@ fn test_tuple_vec() {
 #[serial]
 fn test_out_of_bounds() {
     with_graph(|graph| {
-        let out_of_bounds_result: RedisGraphResult<(i64, String, bool)> = graph.query("RETURN 42, 'Hello, world!'");
+        let out_of_bounds_result: RedisGraphResult<(i64, String, bool)> =
+            graph.query("RETURN 42, 'Hello, world!'");
         assert!(out_of_bounds_result.is_err());
     });
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -8,7 +8,7 @@ pub fn get_connection() -> Connection {
 }
 
 #[allow(dead_code)]
-pub fn with_graph<F: FnOnce(&mut Graph) -> ()>(action: F) {
+pub fn with_graph<F: FnOnce(&mut Graph)>(action: F) {
     let conn = get_connection();
     let mut graph = Graph::open(conn, "test_graph".to_string()).unwrap();
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -2,10 +2,12 @@ use redis::{Client, Connection};
 use redisgraph::graph::Graph;
 
 pub fn get_connection() -> Connection {
-    let client = Client::open("redis://127.0.0.1").expect("Failed to open client!");
+    let client = Client::open(option_env!("TEST_REDIS_URI").unwrap_or("redis://127.0.0.1"))
+        .expect("Failed to open client!");
     client.get_connection().expect("Failed to get connection!")
 }
 
+#[allow(dead_code)]
 pub fn with_graph<F: FnOnce(&mut Graph) -> ()>(action: F) {
     let conn = get_connection();
     let mut graph = Graph::open(conn, "test_graph".to_string()).unwrap();

--- a/tests/conversions_test.rs
+++ b/tests/conversions_test.rs
@@ -153,10 +153,10 @@ fn test_relation() {
 fn test_path() {
     with_graph(|graph| {
         graph
-            .mutate("CREATE (:L1 {prop: 42})-[:REL {prop: 44}]->(:L2 {prop: 43})")
+            .mutate("CREATE (:L1 {prop: 1})-[:R1 {prop: 2}]->(:L2 {prop: 3})-[:R2 {prop: 4}]->(:L3 {prop: 5})")
             .unwrap();
         let path: Path = graph
-            .query("MATCH p = (:L1)-[:REL]->(:L2) RETURN p")
+            .query("MATCH p = (:L1)-[:R1]->(:L2)-[:R2]->(:L3) RETURN p")
             .unwrap();
         assert_eq!(
             path,
@@ -165,22 +165,36 @@ fn test_path() {
                     Node {
                         labels: vec!["L1".to_string().into()],
                         properties: hashmap! {
-                            "prop".to_string().into() => Scalar::Integer(42),
+                            "prop".to_string().into() => Scalar::Integer(1),
                         },
                     },
                     Node {
                         labels: vec!["L2".to_string().into()],
                         properties: hashmap! {
-                            "prop".to_string().into() => Scalar::Integer(43),
+                            "prop".to_string().into() => Scalar::Integer(3),
+                        },
+                    },
+                    Node {
+                        labels: vec!["L3".to_string().into()],
+                        properties: hashmap! {
+                            "prop".to_string().into() => Scalar::Integer(5),
                         },
                     },
                 ],
-                edges: vec![Relation {
-                    type_name: "REL".to_string().into(),
-                    properties: hashmap! {
-                        "prop".to_string().into() => Scalar::Integer(44),
+                edges: vec![
+                    Relation {
+                        type_name: "R1".to_string().into(),
+                        properties: hashmap! {
+                            "prop".to_string().into() => Scalar::Integer(2),
+                        },
                     },
-                }]
+                    Relation {
+                        type_name: "R2".to_string().into(),
+                        properties: hashmap! {
+                            "prop".to_string().into() => Scalar::Integer(4),
+                        },
+                    }
+                ]
             }
         );
     });

--- a/tests/conversions_test.rs
+++ b/tests/conversions_test.rs
@@ -1,13 +1,13 @@
-mod common;
-
 use maplit::hashmap;
-use redisgraph::{
-    result_set::{Node, Path, Edge, Scalar},
-    RedisString,
-};
 use serial_test::serial;
 
 use common::*;
+use redisgraph::{
+    RedisString,
+    result_set::{Edge, Node, Path, RawPath, Scalar},
+};
+
+mod common;
 
 #[test]
 #[serial]
@@ -158,9 +158,65 @@ fn test_path() {
         let path: Path = graph
             .query("MATCH p = (:L1)-[:R1]->(:L2)-[:R2]->(:L3) RETURN p")
             .unwrap();
+        assert_eq!(path.len(), 2);
+        let path: RawPath = path.into();
         assert_eq!(
             path,
-            Path {
+            RawPath {
+                nodes: vec![
+                    Node {
+                        labels: vec!["L1".to_string().into()],
+                        properties: hashmap! {
+                            "prop".to_string().into() => Scalar::Integer(1),
+                        },
+                    },
+                    Node {
+                        labels: vec!["L2".to_string().into()],
+                        properties: hashmap! {
+                            "prop".to_string().into() => Scalar::Integer(3),
+                        },
+                    },
+                    Node {
+                        labels: vec!["L3".to_string().into()],
+                        properties: hashmap! {
+                            "prop".to_string().into() => Scalar::Integer(5),
+                        },
+                    },
+                ],
+                edges: vec![
+                    Edge {
+                        type_name: "R1".to_string().into(),
+                        properties: hashmap! {
+                            "prop".to_string().into() => Scalar::Integer(2),
+                        },
+                    },
+                    Edge {
+                        type_name: "R2".to_string().into(),
+                        properties: hashmap! {
+                            "prop".to_string().into() => Scalar::Integer(4),
+                        },
+                    }
+                ]
+            }
+        );
+    });
+}
+
+
+#[test]
+#[serial]
+fn test_raw_path() {
+    with_graph(|graph| {
+        graph
+            .mutate("CREATE (:L1 {prop: 1})-[:R1 {prop: 2}]->(:L2 {prop: 3})-[:R2 {prop: 4}]->(:L3 {prop: 5})")
+            .unwrap();
+        let path: RawPath = graph
+            .query("MATCH p = (:L1)-[:R1]->(:L2)-[:R2]->(:L3) RETURN p")
+            .unwrap();
+        assert_eq!(path.len(), 2);
+        assert_eq!(
+            path,
+            RawPath {
                 nodes: vec![
                     Node {
                         labels: vec!["L1".to_string().into()],

--- a/tests/conversions_test.rs
+++ b/tests/conversions_test.rs
@@ -2,7 +2,7 @@ mod common;
 
 use maplit::hashmap;
 use redisgraph::{
-    result_set::{Node, Path, Relation, Scalar},
+    result_set::{Node, Path, Edge, Scalar},
     RedisString,
 };
 use serial_test::serial;
@@ -130,15 +130,15 @@ fn test_nodes() {
 
 #[test]
 #[serial]
-fn test_relation() {
+fn test_edge() {
     with_graph(|graph| {
         graph
             .mutate("CREATE (src)-[rel:RelationType { prop: 42 }]->(dst)")
             .unwrap();
-        let relation: Relation = graph.query("MATCH (src)-[rel]->(dst) RETURN rel").unwrap();
+        let relation: Edge = graph.query("MATCH (src)-[rel]->(dst) RETURN rel").unwrap();
         assert_eq!(
             relation,
-            Relation {
+            Edge {
                 type_name: "RelationType".to_string().into(),
                 properties: hashmap! {
                     "prop".to_string().into() => Scalar::Integer(42),
@@ -182,13 +182,13 @@ fn test_path() {
                     },
                 ],
                 edges: vec![
-                    Relation {
+                    Edge {
                         type_name: "R1".to_string().into(),
                         properties: hashmap! {
                             "prop".to_string().into() => Scalar::Integer(2),
                         },
                     },
-                    Relation {
+                    Edge {
                         type_name: "R2".to_string().into(),
                         properties: hashmap! {
                             "prop".to_string().into() => Scalar::Integer(4),


### PR DESCRIPTION
* Nodes and Relations/Edges are now scalar types, and appear in the Scalars column
* Node/Relation columns kept for backwards compatibility
* Added support for new `Path` type